### PR TITLE
Replacement of "compile" with "implementation"

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ To include in your project, check: https://jitpack.io/#ZieIony/MaterialRecents
     }
 	
     dependencies {
-        compile 'com.github.ZieIony:MaterialRecents:master-SNAPSHOT'
+        implementation 'com.github.ZieIony:MaterialRecents:master-SNAPSHOT'
     }
 
 ##### Usage


### PR DESCRIPTION
As "compile" is going to be deprecated end-2018, this PR replaces with "implementation" that is the new usage.